### PR TITLE
Only install psycopg2 when db is PostgreSQL

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/local.txt
+++ b/{{cookiecutter.project_slug}}/requirements/local.txt
@@ -2,8 +2,9 @@
 
 Werkzeug==1.0.1 # https://github.com/pallets/werkzeug
 ipdb==0.13.2  # https://github.com/gotcha/ipdb
+{%- if cookiecutter.database == 'PostgreSQL' -%}
 psycopg2-binary==2.8.5  # https://github.com/psycopg/psycopg2
-
+{%- endif %}
 
 # Testing
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -3,6 +3,8 @@
 -r ./base.txt
 
 gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
+{%- if cookiecutter.database == 'PostgreSQL' -%}
 psycopg2==2.8.5 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
+{%- endif %}
 Collectfast==2.1.0  # https://github.com/antonagestam/collectfast
 django-anymail[mailgun]==7.0.0


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.md` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

I wanted to follow the book using sqlite and `pip install` failed.


## Rationale

[//]: # (Why does the project need that?)

Hope others won't stumble upon this.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

If I choose Sqlite as my database of choice. The project generator assumes I have PostgresSQL installed in the system.
