### PR TITLE
Require django-redis==4.11.0 in production

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements/production.txt
+++ b/{{cookiecutter.project_slug}}/requirements/production.txt
@@ -6,3 +6,4 @@ gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
 psycopg2==2.8.5 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
 Collectfast==2.1.0  # https://github.com/antonagestam/collectfast
 django-anymail[mailgun]==7.0.0
+django-redis==4.11.0  # https://github.com/jazzband/django-redis


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.md` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

Running the generated project with `config.settings.production` results in

```
app_1       | django.core.cache.backends.base.InvalidCacheBackendError: Could not find backend 'django_redis.cache.RedisCache': No module named 'django_redis'
```


## Rationale

[//]: # (Why does the project need that?)

It's a bug fix.


## Use case(s) / visualization(s)

[//]: # ("Better to see something once than to hear about it a thousand times.")

Just run the generated project with `DJANGO_SETTINGS_MODULE` env set to `config.settings.production`.