### PR TITLE
Migrate to pathlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Change Log
 All enhancements and patches to Cookiecutter Django will be documented in this file.
 
+## [2020-07-02]
+### Changed
+- Migrate to pathlib - [@luzfcb](https://github.com/luzfcb)
+
+## [2020-06-29]
+### Changed
+- Update tox to 3.16.0 - [@luzfcb](https://github.com/luzfcb)
+
+## [2020-06-22]
+### Changed
+- Switch to dark navbar - [@pydanny](https://github.com/pydanny)
+
+## [2020-06-18]
+### Changed
+- Update flake8 to 3.8.3 - [@luzfcb](https://github.com/luzfcb)
+- Update pytest to 5.4.3 - [@luzfcb](https://github.com/luzfcb)
+
+## [2020-06-12]
+### Changed
+- Small fixes in the .coveragerc file - [@pydanny](https://github.com/pydanny)
+
+
 ## [2020-06-01]
 ### Changed
 - Fixed the project generation when select database=SQLite and windows=n - [@luzfcb](https://github.com/luzfcb)

--- a/{{cookiecutter.project_slug}}/config/asgi.py
+++ b/{{cookiecutter.project_slug}}/config/asgi.py
@@ -9,18 +9,15 @@ https://docs.djangoproject.com/en/dev/howto/deployment/asgi/
 
 import os
 import sys
+from pathlib import Path
 
 from django.core.asgi import get_asgi_application
 
 
 # This allows easy placement of apps within the interior
 # {{ cookiecutter.project_slug }} directory.
-app_path = os.path.abspath(
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), os.pardir
-    )
-)
-sys.path.append(os.path.join(app_path, "{{ cookiecutter.project_slug }}"))
+ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent
+sys.path.append(str(ROOT_DIR / "{{ cookiecutter.project_slug }}"))
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
 # if running multiple sites in the same mod_wsgi process. To fix this, use
 # mod_wsgi daemon mode with each site in its own daemon process, or use

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -2,14 +2,13 @@
 Base settings to build other settings files upon.
 """
 
-import os  # noqa: F401
+from pathlib import Path
 
 import environ
 
-BASE_DIR = (
-    environ.Path(__file__) - 3
-)  # ({{ cookiecutter.project_slug }}/config/settings/base.py - 3 = {{ cookiecutter.project_slug }}/)
-APPS_DIR = BASE_DIR.path("{{ cookiecutter.project_slug }}")
+# {{ cookiecutter.project_slug }}/
+BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
+APPS_DIR = BASE_DIR / "{{ cookiecutter.project_slug }}"
 
 env = environ.Env()
 
@@ -18,7 +17,7 @@ READ_DOT_ENV_FILE = env.bool(
 )
 if READ_DOT_ENV_FILE:
     # OS environment variables take precedence over variables from .env
-    env.read_env(str(BASE_DIR.path(".env")))
+    env.read_env(str(BASE_DIR / ".env"))
 
 # GENERAL
 # ------------------------------------------------------------------------------
@@ -40,7 +39,7 @@ USE_L10N = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-tz
 USE_TZ = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#locale-paths
-LOCALE_PATHS = [BASE_DIR.path("locale")]
+LOCALE_PATHS = [str(BASE_DIR / "locale")]
 
 # DATABASES
 # ------------------------------------------------------------------------------
@@ -49,7 +48,7 @@ LOCALE_PATHS = [BASE_DIR.path("locale")]
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'everycheese.db'),
+        'NAME': str(BASE_DIR / 'everycheese.db'),
     }
 }
 {%- else -%}
@@ -167,11 +166,11 @@ MIDDLEWARE = [
 # STATIC
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-root
-STATIC_ROOT = str(BASE_DIR("staticfiles"))
+STATIC_ROOT = str(BASE_DIR / "staticfiles")
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
 STATIC_URL = "/static/"
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
-STATICFILES_DIRS = [str(APPS_DIR.path("static"))]
+STATICFILES_DIRS = [str(APPS_DIR / "static")]
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#staticfiles-finders
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",
@@ -181,7 +180,7 @@ STATICFILES_FINDERS = [
 # MEDIA
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-root
-MEDIA_ROOT = str(APPS_DIR("media"))
+MEDIA_ROOT = str(APPS_DIR / "media")
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-url
 MEDIA_URL = "/media/"
 
@@ -193,7 +192,7 @@ TEMPLATES = [
         # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-TEMPLATES-BACKEND
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         # https://docs.djangoproject.com/en/dev/ref/settings/#template-dirs
-        "DIRS": [str(APPS_DIR.path("templates"))],
+        "DIRS": [str(APPS_DIR / "templates")],
         "OPTIONS": {
             # https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders
             # https://docs.djangoproject.com/en/dev/ref/templates/api/#loader-types
@@ -226,7 +225,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap4"
 # FIXTURES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#fixture-dirs
-FIXTURE_DIRS = (str(APPS_DIR.path("fixtures")),)
+FIXTURE_DIRS = (str(APPS_DIR / "fixtures"),)
 
 # SECURITY
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/config/wsgi.py
+++ b/{{cookiecutter.project_slug}}/config/wsgi.py
@@ -15,17 +15,14 @@ framework.
 """
 import os
 import sys
+from pathlib import Path
 
 from django.core.wsgi import get_wsgi_application
 
 # This allows easy placement of apps within the interior
 # {{ cookiecutter.project_slug }} directory.
-app_path = os.path.abspath(
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), os.pardir
-    )
-)
-sys.path.append(os.path.join(app_path, "{{ cookiecutter.project_slug }}"))
+ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent
+sys.path.append(str(ROOT_DIR / "{{ cookiecutter.project_slug }}"))
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
 # if running multiple sites in the same mod_wsgi process. To fix this, use
 # mod_wsgi daemon mode with each site in its own daemon process, or use

--- a/{{cookiecutter.project_slug}}/manage.py
+++ b/{{cookiecutter.project_slug}}/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+from pathlib import Path
 
 if __name__ == "__main__":
     os.environ.setdefault(
@@ -28,7 +29,7 @@ if __name__ == "__main__":
 
     # This allows easy placement of apps within the interior
     # {{ cookiecutter.project_slug }} directory.
-    current_path = os.path.dirname(os.path.abspath(__file__))
-    sys.path.append(os.path.join(current_path, "{{ cookiecutter.project_slug }}"))
+    current_path = Path(__file__).parent.resolve()
+    sys.path.append(str(current_path / "{{ cookiecutter.project_slug }}"))
 
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
## Description

- Migrate the project to use the `pathlib`

## Rationale

[//]: # (Why does the project need that?)

- django 3.1 (alpha 1) [migrated to `pathlib`](https://github.com/django/django/pull/12005), this anticipates the same update


