### PR TITLE
Fix coverage.py + django_coverage_plugin unexpected warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All enhancements and patches to Cookiecutter Django will be documented in this file.
 
+## [2020-09-10]
+### Changed
+- Added a workaround on config/settings/test.py to fix the coverage.py + django_coverage_plugin "Can't add file tracer data for unmeasured file" warning message (https://github.com/feldroy/django-crash-course/issues/329) - [@luzfcb](https://github.com/luzfcb)
+
 ## [2020-09-09]
 ### Changed
 - Removed env.sample file - [@luzfcb](https://github.com/luzfcb)

--- a/{{cookiecutter.project_slug}}/config/settings/test.py
+++ b/{{cookiecutter.project_slug}}/config/settings/test.py
@@ -43,6 +43,10 @@ TEMPLATES[-1]["OPTIONS"]["loaders"] = [  # type: ignore[index] # noqa: F405
         ],
     )
 ]
+# Workaround to:
+# https://github.com/nedbat/coveragepy/issues/1011
+# https://github.com/nedbat/django_coverage_plugin/issues/69
+TEMPLATES[-1]["OPTIONS"]["debug"] = True  # type: ignore[index] # noqa: F405
 
 # EMAIL
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
[//]: # (Thank you for helping us out: your efforts mean great deal to the project and the community as a whole!)

[//]: # (Before you proceed:)

[//]: # (1. Make sure to add yourself to `CONTRIBUTORS.md` through this PR provided you're contributing here for the first time)
[//]: # (2. Don't forget to update the `docs/` presuming others would benefit from a concise description of whatever that you're proposing)


## Description

[//]: # (What's it you're proposing?)

- Fix coverage.py + django_coverage_plugin unexpected warning message to fix feldroy/django-crash-course/issues/329

This pull-request basically causes coverage.py + django_coverage_plugin running correctly and stop showing the warning message.

Full example of the error:
```bash
$ coverage run -m pytest
Test session starts (platform: darwin, Python 3.8.2, pytest 6.0.1, pytest-sugar 0.9.3)
django: settings: config.settings.test (from option)
rootdir: /Users/luzfcb/projects/feldroy/everycheese, configfile: pytest.ini
plugins: django-3.9.0, django-test-plus-1.4.0, sugar-0.9.3, Faker-4.1.2
collecting ...
 everycheese/cheeses/tests/test_models.py ✓✓                           8% ▉
 everycheese/cheeses/tests/test_urls.py ✓✓✓✓✓✓                        33% ███▍
 everycheese/cheeses/tests/test_views.py ✓✓✓✓✓✓✓                      62% ██████▍
 everycheese/users/tests/test_forms.py ✓                              67% ██████▋
 everycheese/users/tests/test_models.py ✓                             71% ███████▏
 everycheese/users/tests/test_urls.py ✓✓✓                             83% ████████▍
 everycheese/users/tests/test_views.py ✓✓✓✓                          100% ██████████

Results (1.36s):
      24 passed

Can't add file tracer data for unmeasured file '/Users/luzfcb/projects/feldroy/everycheese/everycheese/templates/cheeses/cheese_list.html'

```
